### PR TITLE
feat: add read-only status properties to network_interface

### DIFF
--- a/docs/data-sources/network_interface.md
+++ b/docs/data-sources/network_interface.md
@@ -42,5 +42,27 @@ data "openwrt_network_interface" "br_testing" {
 - `proto` (String) The protocol type of the interface. Currently, only "dhcp, and "static" are supported.
 - `reqaddress` (String) Behavior for requesting address. Can only be one of "force", "try", or "none".
 - `reqprefix` (String) Behavior for requesting prefixes. Currently, only "auto" is supported.
+- `ipv4_addresses` (List of String) IPv4 addresses assigned to the interface
+- `up` (Boolean) Whether the interface is up
+- `pending` (Boolean) Whether the interface is pending
+- `available` (Boolean) Whether the interface is available
+- `autostart` (Boolean) Whether the interface starts automatically
+- `dynamic` (Boolean) Whether the interface is dynamically created
+- `uptime` (Number) Time since the interface was brought up
+- `l3_device` (String) Name of the layer 3 device
+- `ifname` (String) Name of the interface
+- `updated` (Number) Last update time
+- `dns_metric` (Number) DNS metric
+- `dns_server` (List of String) DNS servers provided by the interface
+- `dns_search` (List of String) DNS search domains
+- `ipv6_prefix` (List of String) IPv6 prefixes assigned to the interface
+- `ipv6_prefix_assignment` (List of String) IPv6 prefix assignments
+- `route` (List of String) Routes associated with the interface
+- `errors` (List of String) Errors reported by the interface
+- `rx_bytes` (Number) Number of received bytes
+- `tx_bytes` (Number) Number of transmitted bytes
+- `rx_packets` (Number) Number of received packets
+- `tx_packets` (Number) Number of transmitted packets
+- `interface` (String) Interface name
 
 

--- a/docs/resources/network_interface.md
+++ b/docs/resources/network_interface.md
@@ -62,6 +62,31 @@ resource "openwrt_network_interface" "testing" {
 - `reqaddress` (String) Behavior for requesting address. Can only be one of "force", "try", or "none".
 - `reqprefix` (String) Behavior for requesting prefixes. Currently, only "auto" is supported.
 
+### Read-Only
+
+- `ipv4_addresses` (List of String) IPv4 addresses assigned to the interface
+- `up` (Boolean) Whether the interface is up
+- `pending` (Boolean) Whether the interface is pending
+- `available` (Boolean) Whether the interface is available
+- `autostart` (Boolean) Whether the interface starts automatically
+- `dynamic` (Boolean) Whether the interface is dynamically created
+- `uptime` (Number) Time since the interface was brought up
+- `l3_device` (String) Name of the layer 3 device
+- `ifname` (String) Name of the interface
+- `updated` (Number) Last update time
+- `dns_metric` (Number) DNS metric
+- `dns_server` (List of String) DNS servers provided by the interface
+- `dns_search` (List of String) DNS search domains
+- `ipv6_prefix` (List of String) IPv6 prefixes assigned to the interface
+- `ipv6_prefix_assignment` (List of String) IPv6 prefix assignments
+- `route` (List of String) Routes associated with the interface
+- `errors` (List of String) Errors reported by the interface
+- `rx_bytes` (Number) Number of received bytes
+- `tx_bytes` (Number) Number of transmitted bytes
+- `rx_packets` (Number) Number of received packets
+- `tx_packets` (Number) Number of transmitted packets
+- `interface` (String) Interface name
+
 ## Import
 
 Import is supported using the following syntax:

--- a/openwrt/network/networkinterface/interface.go
+++ b/openwrt/network/networkinterface/interface.go
@@ -340,54 +340,123 @@ func NewResource() resource.Resource {
 }
 
 type model struct {
-	BringUpOnBoot     types.Bool   `tfsdk:"auto"`
-	Device            types.String `tfsdk:"device"`
-	Disabled          types.Bool   `tfsdk:"disabled"`
-	DNS               types.List   `tfsdk:"dns"`
-	Gateway           types.String `tfsdk:"gateway"`
-	Id                types.String `tfsdk:"id"`
-	IP6Assign         types.Int64  `tfsdk:"ip6assign"`
-	IPAddress         types.String `tfsdk:"ipaddr"`
-	MacAddress        types.String `tfsdk:"macaddr"`
-	MTU               types.Int64  `tfsdk:"mtu"`
-	Netmask           types.String `tfsdk:"netmask"`
-	PeerDNS           types.Bool   `tfsdk:"peerdns"`
-	Protocol          types.String `tfsdk:"proto"`
-	RequestingAddress types.String `tfsdk:"reqaddress"`
-	RequestingPrefix  types.String `tfsdk:"reqprefix"`
-	Metric            types.Int64  `tfsdk:"metric"`
+	BringUpOnBoot        types.Bool   `tfsdk:"auto"`
+	Device               types.String `tfsdk:"device"`
+	Disabled             types.Bool   `tfsdk:"disabled"`
+	DNS                  types.List   `tfsdk:"dns"`
+	Gateway              types.String `tfsdk:"gateway"`
+	Id                   types.String `tfsdk:"id"`
+	IP6Assign            types.Int64  `tfsdk:"ip6assign"`
+	IPAddress            types.String `tfsdk:"ipaddr"`
+	MacAddress           types.String `tfsdk:"macaddr"`
+	MTU                  types.Int64  `tfsdk:"mtu"`
+	Netmask              types.String `tfsdk:"netmask"`
+	PeerDNS              types.Bool   `tfsdk:"peerdns"`
+	Protocol             types.String `tfsdk:"proto"`
+	RequestingAddress    types.String `tfsdk:"reqaddress"`
+	RequestingPrefix     types.String `tfsdk:"reqprefix"`
+	Metric               types.Int64  `tfsdk:"metric"`
+	IPv4Addresses        types.List   `tfsdk:"ipv4_addresses"`
+	Up                   types.Bool   `tfsdk:"up"`
+	Pending              types.Bool   `tfsdk:"pending"`
+	Available            types.Bool   `tfsdk:"available"`
+	Autostart            types.Bool   `tfsdk:"autostart"`
+	Dynamic              types.Bool   `tfsdk:"dynamic"`
+	Uptime               types.Int64  `tfsdk:"uptime"`
+	L3Device             types.String `tfsdk:"l3_device"`
+	Ifname               types.String `tfsdk:"ifname"`
+	Updated              types.Int64  `tfsdk:"updated"`
+	DNSMetric            types.Int64  `tfsdk:"dns_metric"`
+	DNSServer            types.List   `tfsdk:"dns_server"`
+	DNSSearch            types.List   `tfsdk:"dns_search"`
+	IPv6Prefix           types.List   `tfsdk:"ipv6_prefix"`
+	IPv6PrefixAssignment types.List   `tfsdk:"ipv6_prefix_assignment"`
+	Route                types.List   `tfsdk:"route"`
+	Data                 types.Map    `tfsdk:"data"`
+	Errors               types.List   `tfsdk:"errors"`
+	RxBytes              types.Int64  `tfsdk:"rx_bytes"`
+	TxBytes              types.Int64  `tfsdk:"tx_bytes"`
+	RxPackets            types.Int64  `tfsdk:"rx_packets"`
+	TxPackets            types.Int64  `tfsdk:"tx_packets"`
+	Interface            types.String `tfsdk:"interface"`
 }
 
-func modelGetMetric(m model) types.Int64             { return m.Metric }
-func modelGetBringUpOnBoot(m model) types.Bool       { return m.BringUpOnBoot }
-func modelGetDevice(m model) types.String            { return m.Device }
-func modelGetDisabled(m model) types.Bool            { return m.Disabled }
-func modelGetDNS(m model) types.List                 { return m.DNS }
-func modelGetGateway(m model) types.String           { return m.Gateway }
-func modelGetId(m model) types.String                { return m.Id }
-func modelGetIP6Assign(m model) types.Int64          { return m.IP6Assign }
-func modelGetIPAddress(m model) types.String         { return m.IPAddress }
-func modelGetMacAddress(m model) types.String        { return m.MacAddress }
-func modelGetMTU(m model) types.Int64                { return m.MTU }
-func modelGetNetmask(m model) types.String           { return m.Netmask }
-func modelGetPeerDNS(m model) types.Bool             { return m.PeerDNS }
-func modelGetProtocol(m model) types.String          { return m.Protocol }
-func modelGetRequestingAddress(m model) types.String { return m.RequestingAddress }
-func modelGetRequestingPrefix(m model) types.String  { return m.RequestingPrefix }
+func modelGetMetric(m model) types.Int64              { return m.Metric }
+func modelGetBringUpOnBoot(m model) types.Bool        { return m.BringUpOnBoot }
+func modelGetDevice(m model) types.String             { return m.Device }
+func modelGetDisabled(m model) types.Bool             { return m.Disabled }
+func modelGetDNS(m model) types.List                  { return m.DNS }
+func modelGetGateway(m model) types.String            { return m.Gateway }
+func modelGetId(m model) types.String                 { return m.Id }
+func modelGetIP6Assign(m model) types.Int64           { return m.IP6Assign }
+func modelGetIPAddress(m model) types.String          { return m.IPAddress }
+func modelGetMacAddress(m model) types.String         { return m.MacAddress }
+func modelGetMTU(m model) types.Int64                 { return m.MTU }
+func modelGetNetmask(m model) types.String            { return m.Netmask }
+func modelGetPeerDNS(m model) types.Bool              { return m.PeerDNS }
+func modelGetProtocol(m model) types.String           { return m.Protocol }
+func modelGetRequestingAddress(m model) types.String  { return m.RequestingAddress }
+func modelGetRequestingPrefix(m model) types.String   { return m.RequestingPrefix }
+func modelGetIPv4Addresses(m model) types.List        { return m.IPv4Addresses }
+func modelGetUp(m model) types.Bool                   { return m.Up }
+func modelGetPending(m model) types.Bool              { return m.Pending }
+func modelGetAvailable(m model) types.Bool            { return m.Available }
+func modelGetAutostart(m model) types.Bool            { return m.Autostart }
+func modelGetDynamic(m model) types.Bool              { return m.Dynamic }
+func modelGetUptime(m model) types.Int64              { return m.Uptime }
+func modelGetL3Device(m model) types.String           { return m.L3Device }
+func modelGetIfname(m model) types.String             { return m.Ifname }
+func modelGetUpdated(m model) types.Int64             { return m.Updated }
+func modelGetDNSMetric(m model) types.Int64           { return m.DNSMetric }
+func modelGetDNSServer(m model) types.List            { return m.DNSServer }
+func modelGetDNSSearch(m model) types.List            { return m.DNSSearch }
+func modelGetIPv6Prefix(m model) types.List           { return m.IPv6Prefix }
+func modelGetIPv6PrefixAssignment(m model) types.List { return m.IPv6PrefixAssignment }
+func modelGetRoute(m model) types.List                { return m.Route }
+func modelGetData(m model) types.Map                  { return m.Data }
+func modelGetErrors(m model) types.List               { return m.Errors }
+func modelGetRxBytes(m model) types.Int64             { return m.RxBytes }
+func modelGetTxBytes(m model) types.Int64             { return m.TxBytes }
+func modelGetRxPackets(m model) types.Int64           { return m.RxPackets }
+func modelGetTxPackets(m model) types.Int64           { return m.TxPackets }
+func modelGetInterface(m model) types.String          { return m.Interface }
 
-func modelSetMetric(m *model, value types.Int64)             { m.Metric = value }
-func modelSetBringUpOnBoot(m *model, value types.Bool)       { m.BringUpOnBoot = value }
-func modelSetDevice(m *model, value types.String)            { m.Device = value }
-func modelSetDisabled(m *model, value types.Bool)            { m.Disabled = value }
-func modelSetDNS(m *model, value types.List)                 { m.DNS = value }
-func modelSetGateway(m *model, value types.String)           { m.Gateway = value }
-func modelSetId(m *model, value types.String)                { m.Id = value }
-func modelSetIP6Assign(m *model, value types.Int64)          { m.IP6Assign = value }
-func modelSetIPAddress(m *model, value types.String)         { m.IPAddress = value }
-func modelSetMacAddress(m *model, value types.String)        { m.MacAddress = value }
-func modelSetMTU(m *model, value types.Int64)                { m.MTU = value }
-func modelSetNetmask(m *model, value types.String)           { m.Netmask = value }
-func modelSetPeerDNS(m *model, value types.Bool)             { m.PeerDNS = value }
-func modelSetProtocol(m *model, value types.String)          { m.Protocol = value }
-func modelSetRequestingAddress(m *model, value types.String) { m.RequestingAddress = value }
-func modelSetRequestingPrefix(m *model, value types.String)  { m.RequestingPrefix = value }
+func modelSetMetric(m *model, value types.Int64)              { m.Metric = value }
+func modelSetBringUpOnBoot(m *model, value types.Bool)        { m.BringUpOnBoot = value }
+func modelSetDevice(m *model, value types.String)             { m.Device = value }
+func modelSetDisabled(m *model, value types.Bool)             { m.Disabled = value }
+func modelSetDNS(m *model, value types.List)                  { m.DNS = value }
+func modelSetGateway(m *model, value types.String)            { m.Gateway = value }
+func modelSetId(m *model, value types.String)                 { m.Id = value }
+func modelSetIP6Assign(m *model, value types.Int64)           { m.IP6Assign = value }
+func modelSetIPAddress(m *model, value types.String)          { m.IPAddress = value }
+func modelSetMacAddress(m *model, value types.String)         { m.MacAddress = value }
+func modelSetMTU(m *model, value types.Int64)                 { m.MTU = value }
+func modelSetNetmask(m *model, value types.String)            { m.Netmask = value }
+func modelSetPeerDNS(m *model, value types.Bool)              { m.PeerDNS = value }
+func modelSetProtocol(m *model, value types.String)           { m.Protocol = value }
+func modelSetRequestingAddress(m *model, value types.String)  { m.RequestingAddress = value }
+func modelSetRequestingPrefix(m *model, value types.String)   { m.RequestingPrefix = value }
+func modelSetIPv4Addresses(m *model, value types.List)        { m.IPv4Addresses = value }
+func modelSetUp(m *model, value types.Bool)                   { m.Up = value }
+func modelSetPending(m *model, value types.Bool)              { m.Pending = value }
+func modelSetAvailable(m *model, value types.Bool)            { m.Available = value }
+func modelSetAutostart(m *model, value types.Bool)            { m.Autostart = value }
+func modelSetDynamic(m *model, value types.Bool)              { m.Dynamic = value }
+func modelSetUptime(m *model, value types.Int64)              { m.Uptime = value }
+func modelSetL3Device(m *model, value types.String)           { m.L3Device = value }
+func modelSetIfname(m *model, value types.String)             { m.Ifname = value }
+func modelSetUpdated(m *model, value types.Int64)             { m.Updated = value }
+func modelSetDNSMetric(m *model, value types.Int64)           { m.DNSMetric = value }
+func modelSetDNSServer(m *model, value types.List)            { m.DNSServer = value }
+func modelSetDNSSearch(m *model, value types.List)            { m.DNSSearch = value }
+func modelSetIPv6Prefix(m *model, value types.List)           { m.IPv6Prefix = value }
+func modelSetIPv6PrefixAssignment(m *model, value types.List) { m.IPv6PrefixAssignment = value }
+func modelSetRoute(m *model, value types.List)                { m.Route = value }
+func modelSetData(m *model, value types.Map)                  { m.Data = value }
+func modelSetErrors(m *model, value types.List)               { m.Errors = value }
+func modelSetRxBytes(m *model, value types.Int64)             { m.RxBytes = value }
+func modelSetTxBytes(m *model, value types.Int64)             { m.TxBytes = value }
+func modelSetRxPackets(m *model, value types.Int64)           { m.RxPackets = value }
+func modelSetTxPackets(m *model, value types.Int64)           { m.TxPackets = value }
+func modelSetInterface(m *model, value types.String)          { m.Interface = value }

--- a/openwrt/network/networkinterface/interface.go
+++ b/openwrt/network/networkinterface/interface.go
@@ -86,6 +86,94 @@ const (
 	requestingPrefixAuto                 = "auto"
 	requestingPrefixUCIOption            = "reqprefix"
 
+	ipv4AddressesAttribute            = "ipv4_addresses"
+	ipv4AddressesAttributeDescription = "IPv4 addresses assigned to the interface"
+	ipv4AddressesUCIOption            = "ipv4-address"
+
+	upAttribute            = "up"
+	upAttributeDescription = "Whether the interface is up"
+	upUCIOption            = "up"
+
+	pendingAttribute            = "pending"
+	pendingAttributeDescription = "Whether the interface is pending"
+	pendingUCIOption            = "pending"
+
+	availableAttribute            = "available"
+	availableAttributeDescription = "Whether the interface is available"
+	availableUCIOption            = "available"
+
+	autostartAttribute            = "autostart"
+	autostartAttributeDescription = "Whether the interface starts automatically"
+	autostartUCIOption            = "autostart"
+
+	dynamicAttribute            = "dynamic"
+	dynamicAttributeDescription = "Whether the interface is dynamically created"
+	dynamicUCIOption            = "dynamic"
+
+	uptimeAttribute            = "uptime"
+	uptimeAttributeDescription = "Time since the interface was brought up"
+	uptimeUCIOption            = "uptime"
+
+	l3DeviceAttribute            = "l3_device"
+	l3DeviceAttributeDescription = "Name of the layer 3 device"
+	l3DeviceUCIOption            = "l3_device"
+
+	ifnameAttribute            = "ifname"
+	ifnameAttributeDescription = "Name of the interface"
+	ifnameUCIOption            = "ifname"
+
+	updatedAttribute            = "updated"
+	updatedAttributeDescription = "Last update time"
+	updatedUCIOption            = "updated"
+
+	dnsMetricAttribute            = "dns_metric"
+	dnsMetricAttributeDescription = "DNS metric"
+	dnsMetricUCIOption            = "dns_metric"
+
+	dnsServerAttribute            = "dns_server"
+	dnsServerAttributeDescription = "DNS servers provided by the interface"
+	dnsServerUCIOption            = "dns-server"
+
+	dnsSearchAttribute            = "dns_search"
+	dnsSearchAttributeDescription = "DNS search domains"
+	dnsSearchUCIOption            = "dns-search"
+
+	ipv6PrefixAttribute            = "ipv6_prefix"
+	ipv6PrefixAttributeDescription = "IPv6 prefixes assigned to the interface"
+	ipv6PrefixUCIOption            = "ipv6-prefix"
+
+	ipv6PrefixAssignmentAttribute            = "ipv6_prefix_assignment"
+	ipv6PrefixAssignmentAttributeDescription = "IPv6 prefix assignments"
+	ipv6PrefixAssignmentUCIOption            = "ipv6-prefix-assignment"
+
+	routeAttribute            = "route"
+	routeAttributeDescription = "Routes associated with the interface"
+	routeUCIOption            = "route"
+
+	errorsAttribute            = "errors"
+	errorsAttributeDescription = "Errors reported by the interface"
+	errorsUCIOption            = "errors"
+
+	rxBytesAttribute            = "rx_bytes"
+	rxBytesAttributeDescription = "Number of received bytes"
+	rxBytesUCIOption            = "rx_bytes"
+
+	txBytesAttribute            = "tx_bytes"
+	txBytesAttributeDescription = "Number of transmitted bytes"
+	txBytesUCIOption            = "tx_bytes"
+
+	rxPacketsAttribute            = "rx_packets"
+	rxPacketsAttributeDescription = "Number of received packets"
+	rxPacketsUCIOption            = "rx_packets"
+
+	txPacketsAttribute            = "tx_packets"
+	txPacketsAttributeDescription = "Number of transmitted packets"
+	txPacketsUCIOption            = "tx_packets"
+
+	interfaceAttribute            = "interface"
+	interfaceAttributeDescription = "Interface name"
+	interfaceUCIOption            = "interface"
+
 	schemaDescription = "A logic network."
 
 	uciConfig = "network"
@@ -299,23 +387,199 @@ var (
 		},
 	}
 
+	ipv4AddressesSchemaAttribute = lucirpcglue.ListStringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         ipv4AddressesAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionListString(modelSetIPv4Addresses, ipv4AddressesAttribute, ipv4AddressesUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	upSchemaAttribute = lucirpcglue.BoolSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         upAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionBool(modelSetUp, upAttribute, upUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	pendingSchemaAttribute = lucirpcglue.BoolSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         pendingAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionBool(modelSetPending, pendingAttribute, pendingUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	availableSchemaAttribute = lucirpcglue.BoolSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         availableAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionBool(modelSetAvailable, availableAttribute, availableUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	autostartSchemaAttribute = lucirpcglue.BoolSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         autostartAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionBool(modelSetAutostart, autostartAttribute, autostartUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	dynamicSchemaAttribute = lucirpcglue.BoolSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         dynamicAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionBool(modelSetDynamic, dynamicAttribute, dynamicUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	uptimeSchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         uptimeAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionInt64(modelSetUptime, uptimeAttribute, uptimeUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	l3DeviceSchemaAttribute = lucirpcglue.StringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         l3DeviceAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionString(modelSetL3Device, l3DeviceAttribute, l3DeviceUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	ifnameSchemaAttribute = lucirpcglue.StringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         ifnameAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionString(modelSetIfname, ifnameAttribute, ifnameUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	updatedSchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         updatedAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionInt64(modelSetUpdated, updatedAttribute, updatedUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	dnsMetricSchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         dnsMetricAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionInt64(modelSetDNSMetric, dnsMetricAttribute, dnsMetricUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	dnsServerSchemaAttribute = lucirpcglue.ListStringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         dnsServerAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionListString(modelSetDNSServer, dnsServerAttribute, dnsServerUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	dnsSearchSchemaAttribute = lucirpcglue.ListStringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         dnsSearchAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionListString(modelSetDNSSearch, dnsSearchAttribute, dnsSearchUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	ipv6PrefixSchemaAttribute = lucirpcglue.ListStringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         ipv6PrefixAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionListString(modelSetIPv6Prefix, ipv6PrefixAttribute, ipv6PrefixUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	ipv6PrefixAssignmentSchemaAttribute = lucirpcglue.ListStringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         ipv6PrefixAssignmentAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionListString(modelSetIPv6PrefixAssignment, ipv6PrefixAssignmentAttribute, ipv6PrefixAssignmentUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	routeSchemaAttribute = lucirpcglue.ListStringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         routeAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionListString(modelSetRoute, routeAttribute, routeUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	errorsSchemaAttribute = lucirpcglue.ListStringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         errorsAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionListString(modelSetErrors, errorsAttribute, errorsUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	rxBytesSchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         rxBytesAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionInt64(modelSetRxBytes, rxBytesAttribute, rxBytesUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	txBytesSchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         txBytesAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionInt64(modelSetTxBytes, txBytesAttribute, txBytesUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	rxPacketsSchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         rxPacketsAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionInt64(modelSetRxPackets, rxPacketsAttribute, rxPacketsUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	txPacketsSchemaAttribute = lucirpcglue.Int64SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         txPacketsAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionInt64(modelSetTxPackets, txPacketsAttribute, txPacketsUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
+	interfaceSchemaAttribute = lucirpcglue.StringSchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
+		Description:         interfaceAttributeDescription,
+		ReadResponse:        lucirpcglue.ReadResponseOptionString(modelSetInterface, interfaceAttribute, interfaceUCIOption),
+		ResourceExistence:   lucirpcglue.ReadOnly,
+		DataSourceExistence: lucirpcglue.ReadOnly,
+	}
+
 	schemaAttributes = map[string]lucirpcglue.SchemaAttribute[model, lucirpc.Options, lucirpc.Options]{
-		bringUpOnBootAttribute:     bringUpOnBootSchemaAttribute,
-		deviceAttribute:            deviceSchemaAttribute,
-		disabledAttribute:          disabledSchemaAttribute,
-		dnsAttribute:               dnsSchemaAttribute,
-		gatewayAttribute:           gatewaySchemaAttribute,
-		ip6AssignAttribute:         ip6AssignSchemaAttribute,
-		ipAddressAttribute:         ipAddressSchemaAttribute,
-		macAddressAttribute:        macAddressSchemaAttribute,
-		mtuAttribute:               mtuSchemaAttribute,
-		metricAttribute:            metricSchemaAttribute,
-		netmaskAttribute:           netmaskSchemaAttribute,
-		peerDNSAttribute:           peerDNSSchemaAttribute,
-		protocolAttribute:          protocolSchemaAttribute,
-		requestingAddressAttribute: requestingAddressSchemaAttribute,
-		requestingPrefixAttribute:  requestingPrefixSchemaAttribute,
-		lucirpcglue.IdAttribute:    lucirpcglue.IdSchemaAttribute(modelGetId, modelSetId),
+		bringUpOnBootAttribute:        bringUpOnBootSchemaAttribute,
+		deviceAttribute:               deviceSchemaAttribute,
+		disabledAttribute:             disabledSchemaAttribute,
+		dnsAttribute:                  dnsSchemaAttribute,
+		gatewayAttribute:              gatewaySchemaAttribute,
+		ip6AssignAttribute:            ip6AssignSchemaAttribute,
+		ipAddressAttribute:            ipAddressSchemaAttribute,
+		macAddressAttribute:           macAddressSchemaAttribute,
+		mtuAttribute:                  mtuSchemaAttribute,
+		metricAttribute:               metricSchemaAttribute,
+		netmaskAttribute:              netmaskSchemaAttribute,
+		peerDNSAttribute:              peerDNSSchemaAttribute,
+		protocolAttribute:             protocolSchemaAttribute,
+		requestingAddressAttribute:    requestingAddressSchemaAttribute,
+		requestingPrefixAttribute:     requestingPrefixSchemaAttribute,
+		ipv4AddressesAttribute:        ipv4AddressesSchemaAttribute,
+		upAttribute:                   upSchemaAttribute,
+		pendingAttribute:              pendingSchemaAttribute,
+		availableAttribute:            availableSchemaAttribute,
+		autostartAttribute:            autostartSchemaAttribute,
+		dynamicAttribute:              dynamicSchemaAttribute,
+		uptimeAttribute:               uptimeSchemaAttribute,
+		l3DeviceAttribute:             l3DeviceSchemaAttribute,
+		ifnameAttribute:               ifnameSchemaAttribute,
+		updatedAttribute:              updatedSchemaAttribute,
+		dnsMetricAttribute:            dnsMetricSchemaAttribute,
+		dnsServerAttribute:            dnsServerSchemaAttribute,
+		dnsSearchAttribute:            dnsSearchSchemaAttribute,
+		ipv6PrefixAttribute:           ipv6PrefixSchemaAttribute,
+		ipv6PrefixAssignmentAttribute: ipv6PrefixAssignmentSchemaAttribute,
+		routeAttribute:                routeSchemaAttribute,
+		errorsAttribute:               errorsSchemaAttribute,
+		rxBytesAttribute:              rxBytesSchemaAttribute,
+		txBytesAttribute:              txBytesSchemaAttribute,
+		rxPacketsAttribute:            rxPacketsSchemaAttribute,
+		txPacketsAttribute:            txPacketsSchemaAttribute,
+		interfaceAttribute:            interfaceSchemaAttribute,
+		lucirpcglue.IdAttribute:       lucirpcglue.IdSchemaAttribute(modelGetId, modelSetId),
 	}
 )
 


### PR DESCRIPTION
## Summary
- extend network interface model with status fields
- add getters and setters for new status fields

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c651bde454832383a20d82a1029dc3